### PR TITLE
chore: configuracion analisis sonarcloud #56

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,3 +12,5 @@ sonar.projectName=LaJElegante-Python
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
+sonar.python.version=3.12, 3.14
+sonar.exclusions=**/migrations/** , **/tests/** , **/venv/** , **/__pycache__/** , **/img/** , **/images/** , **/*.pyc


### PR DESCRIPTION
- versiones de python de los devs (julian = 3.14.3, jeremy= 3.12.6)
- exclusiones del analisis en archivos autogenerados, dependencias o binarios