### PR TITLE
refactor(rooms): atributo innecesario en Detalles Habitación, Tipo de Habitación

### DIFF
--- a/rooms/models.py
+++ b/rooms/models.py
@@ -11,7 +11,7 @@ class TipoHabitacion(BaseAuditModel):
     ]
 
     nombre_tipo = models.CharField(max_length=20, choices=NOMBRE_TIPO_CHOICES)
-    descripcion = models.TextField(blank=True, null=True)
+    descripcion = models.TextField(blank=True)
     capacidad_maxima = models.PositiveIntegerField()
 
     def __str__(self):
@@ -60,7 +60,7 @@ class DetallesReservaHabitacion(BaseAuditModel):
     recargo_aplicado = models.DecimalField(max_digits=10, decimal_places=2, default=0.0)
     precio_reserva = models.DecimalField(max_digits=12, decimal_places=2)
 
-    observacion = models.TextField(blank=True, null=True)
+    observacion = models.TextField(blank=True)
 
     fecha_inicio = models.DateField()
     fecha_fin = models.DateField()


### PR DESCRIPTION
- No es necesario marcar este atributo debido a que no deberia ser usado en campos string
- SonarCloud Maintibility issues