### PR TITLE
chore: configuración de coverage para sonarcloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,5 +12,6 @@ sonar.projectName=LaJElegante-Python
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
-sonar.python.version=3.12, 3.14
-sonar.exclusions=**/migrations/** , **/tests/** , **/venv/** , **/__pycache__/** , **/img/** , **/images/** , **/*.pyc
+sonar.python.version=3.12,3.14
+sonar.exclusions=**/migrations/**,**/tests/**,**/venv/**,**/__pycache__/**,**/img/**,**/images/**,**/*.pyc
+sonar.coverage.exclusions=**/settings.py,**/wsgi.py,**/asgi.py,**/manage.py,**/urls.py,**/apps.py,**/migrations/**,**/tests.py,**/tests/**,**/__init__.py


### PR DESCRIPTION
- evita analizar codigo que no necesita cobertura real, debido a que no tiene lógica de negocio
- estilos arreglados para mas cohesión (unificar formatos) y evitar errores (propiedades sin espacios)